### PR TITLE
Fixed an import typo in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Many projects that have a need for data validation may also need to work with ph
 from pydantic import BaseModel
 from pydantic_pint import PydanticPintQuantity
 from pint import Quantity
-from typing import Annotations
+from typing import Annotated
 
 class Box(BaseModel):
     length: Annotated[Quantity, PydanticPintQuantity("m")]


### PR DESCRIPTION
Fixed a typo in the README code example

Sorry I didn't raise an issue first - just figured this was minor enough to fix directly.