### PR TITLE
Added number serialization mode 

### DIFF
--- a/changes/1.feature.md
+++ b/changes/1.feature.md
@@ -1,0 +1,1 @@
+Added `"number"` serialization mode to allow users to drop units when serializing a field.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -180,8 +180,8 @@ Use `to_json` to change between these modes if using the serialization function 
 
     print(m.model_dump())
     print(m.model_dump(mode="json"))
-    #> {'quantity': <Quantity(1, 'meter')>}
-    #> {'quantity': '1 meter'}
+    #> {'quantity': <Quantity(1000, 'meter')>}
+    #> {'quantity': '1000 meter'}
     ```
 
 === "To `str`"
@@ -194,8 +194,8 @@ Use `to_json` to change between these modes if using the serialization function 
 
     print(m.model_dump())
     print(m.model_dump(mode="json"))
-    #> {'quantity': '1 meter'}
-    #> {'quantity': '1 meter'}
+    #> {'quantity': '1000 meter'}
+    #> {'quantity': '1000 meter'}
     ```
 
 === "To `dict`"
@@ -208,8 +208,8 @@ Use `to_json` to change between these modes if using the serialization function 
 
     print(m.model_dump())
     print(m.model_dump(mode="json"))
-    #> {'quantity': {'magnitude': 1, 'units': <Unit('meter')>}}
-    #> {'quantity': {'magnitude': 1, 'units': 'meter'}}
+    #> {'quantity': {'magnitude': 1000, 'units': <Unit('meter')>}}
+    #> {'quantity': {'magnitude': 1000, 'units': 'meter'}}
     ```
 
 === "To `number`"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -165,7 +165,7 @@ except ValidationError as e:
 ## Quantity Serialization
 
 `PydanticPintQuantity` can be serialized in different ways, similar to the validation.
-The annotation can have a serialization mode for `"str"`, `"dict"`, or `None` (the default).
+The annotation can have a serialization mode for `"str"`, `"dict"`, `"number"` or `None` (the default).
 The default serialization behavior is to return a `str` or `pint.Quantity`, depending on the whether it produce a JSON serializable object.
 That is, it will return a `str` if in Pydantic's `"json"` mode, and it will return a `pint.Quantity` if in Pydantic's `"python"`.
 Use `to_json` to change between these modes if using the serialization function directly.
@@ -212,16 +212,22 @@ Use `to_json` to change between these modes if using the serialization function 
     #> {'quantity': {'magnitude': 1, 'units': 'meter'}}
     ```
 
-!!! failure "Serializing to a Number"
-
-    Serialization to a number is not permitted due to the loss of information of the units.
-    If you need to get the magnitude of the value, use `"dict"` mode instead for serialization.
-    Users can pull the magnitude easily from the `"magnitude"` key.
+=== "To `number`"
 
     ```python
     class Model(BaseModel):
-        quantity: Annotated[Quantity, PydanticPintQuantity("m", ser_mode="dict")]
+        quantity: Annotated[Quantity, PydanticPintQuantity("m", ser_mode="number")]
 
     m = Model(quantity={"magnitude": 1000, "units": "m"})
-    print(m.model_dump()["magnitude"])
+
+    print(m.model_dump())
+    print(m.model_dump(mode="json"))
+    #> {'quantity': 1000}
+    #> {'quantity': 1000}
     ```
+
+!!! warning "Serializing to a Number"
+
+    Serialization to a number is dangerous due to the loss of information of the units.
+    If you need to get the magnitude of the value, it is recommended to use `"dict"` for serialization mode instead.
+    Users can pull the magnitude easily from the `"magnitude"` key.

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -155,7 +155,7 @@ class PydanticPintQuantity:
 
         # special case when no serialization mode is specified, but
         # need to serialize to a json convertible object
-        if self.ser_mode == "str" or (self.ser_mode is None and to_json):
+        if self.ser_mode == "str" or to_json:
             return f"{v}"
 
         # return the `pint.Quanity` object as is (no serialization)


### PR DESCRIPTION
A new serialization mode is added to allow users to serialize the quantity directly to its magnitude. This will drop the units in the serialization. The original implementation did not implementation due to this loss of information, but ultimately this is an "opt-in" feature, so it is more acceptable to implement this.