### PR TITLE
Add ability to restrict dimensionality

### DIFF
--- a/changes/4.feature.md
+++ b/changes/4.feature.md
@@ -1,0 +1,3 @@
+Allow dimensions restriction on fields using `PydanticPintQuantity`.
+Default changed to automatically deduce restrictions instead of only allowing units.
+Using `restriction="units"` forces the restriction to be on units.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,6 +43,44 @@ In the example below, all the following are equivalent.
     Model(quantity=1000 * ureg.watts * ureg.seconds / ureg.newton)
     ```
 
+### Validation Based on Units or Dimensions
+
+The `PydanticPintQuantity` annotation allows for restrictions based on either units or dimensions.
+By default, it will try to automatically deduce the restriction type.
+To avoid automatic deduction, use `restriction="units"` or `restriction="dimensions"` to be specific.
+
+Restrictions on the unit requires all inputs to the field be convertible to the specified unit.
+The value the model stores has the units specified in the annotation.
+Restrictions on the dimensions only requires input values to be of the specified dimension.
+The units provided (units are required here) are kept.
+This means there is no common / default unit for that field.
+
+=== "Restricting Units"
+
+    ```python
+    class Model(BaseModel):
+        # quantity must be convertible to a "meter" (and will be represented as meters)
+        quantity: Annotated[Quantity, PydanticPintQuantity("m")]
+
+    Model(quantity=1 * ureg.meters)
+    Model(quantity=1 * ureg.inches)
+    #> Model(quantity=<Quantity(1, 'meter')>)
+    #> Model(quantity=<Quantity(0.0254, 'meter')>)
+    ```
+
+=== "Restricting Dimensions"
+
+    ```python
+    class Model(BaseModel):
+        # quantity must have units that measure length (and will keep the units provided)
+        quantity: Annotated[Quantity, PydanticPintQuantity("[length]")]
+
+    Model(quantity=1 * ureg.meters)
+    Model(quantity=1 * ureg.inches)
+    #> Model(quantity=<Quantity(1, 'meter')>)
+    #> Model(quantity=<Quantity(1, 'inch')>)
+    ```
+
 ### Strict Mode
 
 By default, strict mode is enabled which forces users to include units when instantiating the model.

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -71,7 +71,7 @@ class PydanticPintQuantity:
                 _units = self.ureg(_arg)
                 _dims = _units.dimensionality
                 self.restriction = "units"
-            except pint.errors.UndefinedUnitError:
+            except AttributeError:
                 if self.restriction == "units":
                     raise
 


### PR DESCRIPTION
Added the ability to restrict the dimensionality of a field instead of just the units. The default behavior now will try to automatically deduce the restriction based on input. Use `restriction="units"` to force only unit restriction or `restriction="dimensions"` to force only dimension restriction. Typically, dimensions are of the form `[<dimension>]` (e.g. `[length]`).