### PR TITLE
Multiple pint registries clash v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.pixi
+*.egg-info
+__pycache__
+_version.py
+pixi.lock
+pixi.toml
+sandbox.py

--- a/changes/7.fix.md
+++ b/changes/7.fix.md
@@ -1,0 +1,1 @@
+Fixed issue where `PydanticPintQuantity` fields cannot be used with each other due to different unit registries.

--- a/src/pydantic_pint/__init__.py
+++ b/src/pydantic_pint/__init__.py
@@ -9,6 +9,7 @@ except ImportError:
 
 
 __all__ = [
+    "DEFAULT_UNIT_REGISTRY",
     "PydanticPintQuantity",
 ]
 

--- a/src/pydantic_pint/__init__.py
+++ b/src/pydantic_pint/__init__.py
@@ -13,3 +13,4 @@ __all__ = [
 ]
 
 from .quantity import PydanticPintQuantity
+from .registry import DEFAULT_UNIT_REGISTRY

--- a/src/pydantic_pint/__init__.py
+++ b/src/pydantic_pint/__init__.py
@@ -9,9 +9,10 @@ except ImportError:
 
 
 __all__ = [
-    "DEFAULT_UNIT_REGISTRY",
+    "get_unit_registry",
+    "init_unit_registry",
     "PydanticPintQuantity",
 ]
 
 from .quantity import PydanticPintQuantity
-from .registry import DEFAULT_UNIT_REGISTRY
+from .registry import get_unit_registry, init_unit_registry

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -12,6 +12,8 @@ import pint
 from pint.facets.plain.quantity import PlainQuantity as Quantity
 from pydantic_core import core_schema
 
+from pydantic_pint.registry import DEFAULT_UNIT_REGISTRY
+
 
 class PydanticPintQuantity:
     """Pydantic Pint Quantity.
@@ -26,6 +28,7 @@ class PydanticPintQuantity:
             If the field is restricted by dimension, then any unit of that dimension is allowed.
         ureg:
             A custom Pint unit registry.
+            If not specified, the default unit registry `pydantic_pint.registry.DEFAULT_UNIT_REGISTRY` is used.
         ureg_contexts:
             A custom Pint context (or context name) for the default unit registry.
             All contexts are applied in validation conversion.
@@ -55,7 +58,7 @@ class PydanticPintQuantity:
         self.ser_mode = ser_mode.lower() if ser_mode else None
         self.strict = strict
 
-        self.ureg = ureg if ureg else pint.UnitRegistry()
+        self.ureg = ureg if ureg else DEFAULT_UNIT_REGISTRY
         self.ureg_contexts = ureg_contexts if ureg_contexts else []
 
         # if restriction is not specified, try to automatically figure out what to restrict

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -12,7 +12,7 @@ import pint
 from pint.facets.plain.quantity import PlainQuantity as Quantity
 from pydantic_core import core_schema
 
-from pydantic_pint.registry import DEFAULT_UNIT_REGISTRY
+from pydantic_pint.registry import get_unit_registry
 
 
 class PydanticPintQuantity:
@@ -58,7 +58,7 @@ class PydanticPintQuantity:
         self.ser_mode = ser_mode.lower() if ser_mode else None
         self.strict = strict
 
-        self.ureg = ureg if ureg else DEFAULT_UNIT_REGISTRY
+        self.ureg = ureg if ureg else get_unit_registry()
         self.ureg_contexts = ureg_contexts if ureg_contexts else []
 
         # if restriction is not specified, try to automatically figure out what to restrict

--- a/src/pydantic_pint/registry.py
+++ b/src/pydantic_pint/registry.py
@@ -4,4 +4,20 @@ from __future__ import annotations
 
 import pint
 
-DEFAULT_UNIT_REGISTRY = pint.UnitRegistry()
+_registry = pint.UnitRegistry()
+
+
+def get_unit_registry() -> pint.UnitRegistry:
+    """
+    Returns the current unit registry to be used.
+    Always use this function to retrieve the unit registry.
+    """
+    return _registry
+
+
+def init_unit_registry(registry: pint.UnitRegistry) -> None:
+    """
+    Overrides the global unit registry with the provided registry.
+    """
+    global _registry
+    _registry = registry

--- a/src/pydantic_pint/registry.py
+++ b/src/pydantic_pint/registry.py
@@ -1,0 +1,7 @@
+"""Defines the global unit registry for `PydanticPintQuantity`."""
+
+from __future__ import annotations
+
+import pint
+
+DEFAULT_UNIT_REGISTRY = pint.UnitRegistry()


### PR DESCRIPTION
Addressing #7; alternative way of solving the clash and allowing for user to set up global registry by themselves rather than enforcing `pydantic-pint` one on them (which is still possible and if they prefer to use it, there is a utility to retrieve the default one from this package).

User code would look something like this:

```python
from pydantic_pint import (
    PydanticPintQuantity,
    init_unit_registry,
    get_unit_registry,
)
from pint import UnitRegistry, Quantity
from typing import Annotated
from pydantic import BaseModel, Field


if __name__ == "__main__":
    ureg = UnitRegistry()
    print(id(get_unit_registry()))
    init_unit_registry(ureg)
    print(id(get_unit_registry()))
    print(id(ureg))

    class Box(BaseModel):
        length: Annotated[Quantity, PydanticPintQuantity("m"), Field(gt=0)]
        width: Annotated[Quantity, PydanticPintQuantity("m")]

    thebox = Box(
        length="4km",
        width="2m",
    )
    area = thebox.length * thebox.width
    volume = area * ureg.Quantity(3.0, "m")
    print(volume)
```