### PR TITLE
Validation fails when using custom context with dimensions restriction

### DIFF
--- a/changes/28.fix.md
+++ b/changes/28.fix.md
@@ -1,0 +1,3 @@
+Fixed validation of dimensions when using custom contexts.
+Now, custom contexts that are enabled in the unit registry will be utilized during the check.
+To use the old behavior, enable exact mode which forces the users to provide units of the exact dimensions.


### PR DESCRIPTION
New behavior will use transformations when restricting dimensions. Set `exact=True` to get old behavior.