### PR TITLE
Changed schema to allow units to be optional when validating a dictionary

### DIFF
--- a/changes/29.change.md
+++ b/changes/29.change.md
@@ -1,0 +1,2 @@
+Changed schema to allow units to be optional when validating a dictionary.
+The check for requiring units happens later in validation by using `strict`.

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -267,9 +267,12 @@ class PydanticPintQuantity:
         """
         _from_typedict_schema = {
             "magnitude": core_schema.typed_dict_field(
-                core_schema.str_schema(coerce_numbers_to_str=True)
+                core_schema.str_schema(coerce_numbers_to_str=True),
             ),
-            "units": core_schema.typed_dict_field(core_schema.str_schema()),
+            "units": core_schema.typed_dict_field(
+                core_schema.str_schema(),
+                required=False,
+            ),
         }
 
         validate_schema = core_schema.chain_schema(


### PR DESCRIPTION
allow units to be optional in schema when validating a dictionary

- units will be check for later in validation with strict mode