### PR TITLE
Initial Unit Tests for Supported Use Cases

### DIFF
--- a/tests/test_quantity_additional_annotations.py
+++ b/tests/test_quantity_additional_annotations.py
@@ -1,0 +1,137 @@
+
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError, Field
+from pydantic_pint import PydanticPintQuantity, PydanticPintValue, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_additional_annotations_field_gt():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False), Field(gt=PydanticPintValue(0, "m", ureg=ureg))]
+
+    # positive
+    assert TestModel(value=1).value == ureg("1m")
+    assert TestModel(value="1m").value == ureg("1m")
+    assert TestModel(value="1km").value == ureg("1km")
+    assert TestModel(value="1cm").value == ureg("1cm")
+
+    # zero
+    with pytest.raises(ValidationError): TestModel(value=0)
+    with pytest.raises(ValidationError): TestModel(value="0m")
+    with pytest.raises(ValidationError): TestModel(value="0km")
+    with pytest.raises(ValidationError): TestModel(value="0cm")
+
+    # negative
+    with pytest.raises(ValidationError): TestModel(value=-1)
+    with pytest.raises(ValidationError): TestModel(value="-1m")
+    with pytest.raises(ValidationError): TestModel(value="-1km")
+    with pytest.raises(ValidationError): TestModel(value="-1cm")
+
+def test_quantity_additional_annotations_field_ge():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False), Field(ge=PydanticPintValue(0, "m", ureg=ureg))]
+
+    # positive
+    assert TestModel(value=1).value == ureg("1m")
+    assert TestModel(value="1m").value == ureg("1m")
+    assert TestModel(value="1km").value == ureg("1km")
+    assert TestModel(value="1cm").value == ureg("1cm")
+
+    # zero
+    assert TestModel(value=0).value == ureg("0m")
+    assert TestModel(value="0m").value == ureg("0m")
+    assert TestModel(value="0km").value == ureg("0km")
+    assert TestModel(value="0cm").value == ureg("0cm")
+
+    # negative
+    with pytest.raises(ValidationError): TestModel(value=-1)
+    with pytest.raises(ValidationError): TestModel(value="-1m")
+    with pytest.raises(ValidationError): TestModel(value="-1km")
+    with pytest.raises(ValidationError): TestModel(value="-1cm")
+
+def test_quantity_additional_annotations_field_le():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False), Field(le=PydanticPintValue(0, "m", ureg=ureg))]
+
+    # positive
+    with pytest.raises(ValidationError): TestModel(value=1)
+    with pytest.raises(ValidationError): TestModel(value="1m")
+    with pytest.raises(ValidationError): TestModel(value="1km")
+    with pytest.raises(ValidationError): TestModel(value="1cm")
+
+    # zero
+    assert TestModel(value=0).value == ureg("0m")
+    assert TestModel(value="0m").value == ureg("0m")
+    assert TestModel(value="0km").value == ureg("0km")
+    assert TestModel(value="0cm").value == ureg("0cm")
+
+    # negative
+    assert TestModel(value=-1).value == ureg("-1m")
+    assert TestModel(value="-1m").value == ureg("-1m")
+    assert TestModel(value="-1km").value == ureg("-1km")
+    assert TestModel(value="-1cm").value == ureg("-1cm")
+
+def test_quantity_additional_annotations_field_lt():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False), Field(lt=PydanticPintValue(0, "m", ureg=ureg))]
+
+    # positive
+    with pytest.raises(ValidationError): TestModel(value=1)
+    with pytest.raises(ValidationError): TestModel(value="1m")
+    with pytest.raises(ValidationError): TestModel(value="1km")
+    with pytest.raises(ValidationError): TestModel(value="1cm")
+
+    # zero
+    with pytest.raises(ValidationError): TestModel(value=0)
+    with pytest.raises(ValidationError): TestModel(value="0m")
+    with pytest.raises(ValidationError): TestModel(value="0km")
+    with pytest.raises(ValidationError): TestModel(value="0cm")
+
+    # negative
+    assert TestModel(value=-1).value == ureg("-1m")
+    assert TestModel(value="-1m").value == ureg("-1m")
+    assert TestModel(value="-1km").value == ureg("-1km")
+    assert TestModel(value="-1cm").value == ureg("-1cm")
+
+def test_quantity_additional_annotations_field_lt():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False), Field(multiple_of=PydanticPintValue(2, "m", ureg=ureg))]
+
+    # no units
+    assert TestModel(value=0).value == ureg("0m")
+    assert TestModel(value=2).value == ureg("2m")
+    with pytest.raises(ValidationError): TestModel(value=1)
+
+    # meters
+    assert TestModel(value="0m").value == ureg("0m")
+    assert TestModel(value="2m").value == ureg("2m")
+    with pytest.raises(ValidationError): TestModel(value="1m")
+
+    # kilometers
+    assert TestModel(value="1km").value == ureg("1km")
+    assert TestModel(value="0.5km").value == ureg("0.5km")
+    with pytest.raises(ValidationError): TestModel(value="0.001km")
+
+    # centimeters
+    with pytest.raises(ValidationError): TestModel(value="1cm")
+    with pytest.raises(ValidationError): TestModel(value="2cm")
+    assert TestModel(value="200cm").value == ureg("200cm")

--- a/tests/test_quantity_additional_annotations.py
+++ b/tests/test_quantity_additional_annotations.py
@@ -6,7 +6,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError, Field
 from pydantic_pint import PydanticPintQuantity, PydanticPintValue, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_additional_annotations_field_gt():

--- a/tests/test_quantity_compare_metric_prefixes.py
+++ b/tests/test_quantity_compare_metric_prefixes.py
@@ -1,0 +1,177 @@
+
+from __future__ import annotations
+
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_compare_metric_prefixes_1Tm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1Tm")
+    assert x.value.m == 1000000000000
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1000000000000m")
+
+
+def test_quantity_compare_metric_prefixes_1Gm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1Gm")
+    assert x.value.m == 1000000000
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1000000000m")
+
+
+def test_quantity_compare_metric_prefixes_1Mm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1Mm")
+    assert x.value.m == 1000000
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1000000m")
+
+
+def test_quantity_compare_metric_prefixes_1km():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1km")
+    assert x.value.m == 1000
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1000m")
+
+
+def test_quantity_compare_metric_prefixes_1hm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1hm")
+    assert x.value.m == 100
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("100m")
+
+
+def test_quantity_compare_metric_prefixes_1dam():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1dam")
+    assert x.value.m == 10
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("10m")
+
+
+def test_quantity_compare_metric_prefixes_1m():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+def test_quantity_compare_metric_prefixes_1dm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1dm")
+    assert x.value.m == 0.1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("0.1m")
+
+
+def test_quantity_compare_metric_prefixes_1cm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1cm")
+    assert x.value.m == 0.01
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("0.01m")
+
+
+def test_quantity_compare_metric_prefixes_1mm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1mm")
+    assert x.value.m == 0.001
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("0.001m")
+
+
+def test_quantity_compare_metric_prefixes_1μm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1μm")
+    assert x.value.m == 0.000001
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("0.000001m")
+
+
+def test_quantity_compare_metric_prefixes_1nm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1nm")
+    assert x.value.m == 0.000000001
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("0.000000001m")
+
+
+def test_quantity_compare_metric_prefixes_1pm():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    x = TestModel(value="1pm")
+    assert x.value.m == 0.000000000001
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("0.000000000001m")

--- a/tests/test_quantity_compare_metric_prefixes.py
+++ b/tests/test_quantity_compare_metric_prefixes.py
@@ -5,7 +5,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel
 from pydantic_pint import PydanticPintQuantity, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_compare_metric_prefixes_1Tm():

--- a/tests/test_quantity_compare_unitless.py
+++ b/tests/test_quantity_compare_unitless.py
@@ -1,0 +1,94 @@
+
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_compare_unitless_nonstrict_nonexact():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("%", strict=False, exact=False)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("1%")
+
+    x = TestModel(value="1%")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("1%")
+
+    x = TestModel(value="1bit")
+    assert x.value.m == 100
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("100%")
+
+
+def test_quantity_compare_unitless_nonstrict_exact():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("%", strict=False, exact=True)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("1%")
+
+    x = TestModel(value="1%")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("1%")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1bit")
+
+
+def test_quantity_compare_unitless_strict_nonexact():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("%", strict=True, exact=False)]
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+    x = TestModel(value="1%")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("1%")
+
+    x = TestModel(value="1bit")
+    assert x.value.m == 100
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("100%")
+
+
+
+def test_quantity_compare_unitless_strict_exact():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("%", strict=True, exact=True)]
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+    x = TestModel(value="1%")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("%")
+    assert x.value == ureg("1%")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1bit")

--- a/tests/test_quantity_compare_unitless.py
+++ b/tests/test_quantity_compare_unitless.py
@@ -6,7 +6,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError
 from pydantic_pint import PydanticPintQuantity, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_compare_unitless_nonstrict_nonexact():

--- a/tests/test_quantity_construction.py
+++ b/tests/test_quantity_construction.py
@@ -1,0 +1,100 @@
+
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_construction_number_nonstrict():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+def test_quantity_construction_number_strict():
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=True)]
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+
+def test_quantity_construction_str_nonstrict():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False)]
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value="1")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+def test_quantity_construction_str_strict():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=True)]
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1")
+
+
+def test_quantity_construction_dict_nonstrict():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False)]
+
+    x = TestModel(value={"magnitude": 1, "units": "m"})
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value={"magnitude": 1})
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+def test_quantity_construction_dict_strict():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=True)]
+
+    x = TestModel(value={"magnitude": 1, "units": "m"})
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+    with pytest.raises(ValidationError):
+        TestModel(value={"magnitude": 1})

--- a/tests/test_quantity_construction.py
+++ b/tests/test_quantity_construction.py
@@ -6,7 +6,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError
 from pydantic_pint import PydanticPintQuantity, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_construction_number_nonstrict():

--- a/tests/test_quantity_custom_unit_registry.py
+++ b/tests/test_quantity_custom_unit_registry.py
@@ -1,0 +1,71 @@
+
+from __future__ import annotations
+
+import pytest
+from pint import Context, UnitRegistry
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic_pint import PydanticPintQuantity
+
+from typing_extensions import Annotated
+
+
+def test_quantity_custom_unit_registry():
+
+    ureg = UnitRegistry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", ureg=ureg)]
+
+    x = TestModel(value="1m", ureg=ureg)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+def test_quantity_custom_unit_registry_with_custom_transformations():
+
+    ureg = UnitRegistry()
+    ctx = Context()
+    ctx.add_transformation("[length]", "[time]", lambda ureg, x: x / (100 * ureg.miles) * (1.5 * ureg.hours))
+    ctx.add_transformation("[time]", "[length]", lambda ureg, x: x / (1.5 * ureg.hours) * (100 * ureg.miles))
+    ureg.enable_contexts(ctx)
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("hr", ureg=ureg)]
+
+    x = TestModel(value="100mi")
+    assert x.value.m == 1.5
+    assert x.value.u == ureg.Unit("hr")
+    assert x.value == ureg("1.5hr")
+
+    x = TestModel(value="1.5hr")
+    assert x.value.m == 1.5
+    assert x.value.u == ureg.Unit("hr")
+    assert x.value == ureg("1.5hr")
+
+
+def test_quantity_custom_unit_registry_with_custom_transformations_context_switch():
+
+    ureg = UnitRegistry()
+    ctx = Context()
+    ctx.add_transformation("[length]", "[time]", lambda ureg, x: x / (100 * ureg.miles) * (1.5 * ureg.hours))
+    ctx.add_transformation("[time]", "[length]", lambda ureg, x: x / (1.5 * ureg.hours) * (100 * ureg.miles))
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("hr", ureg=ureg)]
+
+    with ureg.context(ctx):
+        x = TestModel(value="100mi")
+        assert x.value.m == 1.5
+        assert x.value.u == ureg.Unit("hr")
+        assert x.value == ureg("1.5hr")
+
+        x = TestModel(value="1.5hr")
+        assert x.value.m == 1.5
+        assert x.value.u == ureg.Unit("hr")
+        assert x.value == ureg("1.5hr")
+
+    # fails when outside context block
+    with pytest.raises(ValidationError):
+        TestModel(value="100mi")

--- a/tests/test_quantity_custom_unit_registry.py
+++ b/tests/test_quantity_custom_unit_registry.py
@@ -7,7 +7,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError
 from pydantic_pint import PydanticPintQuantity
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_custom_unit_registry():

--- a/tests/test_quantity_custom_unit_registry.py
+++ b/tests/test_quantity_custom_unit_registry.py
@@ -23,6 +23,27 @@ def test_quantity_custom_unit_registry():
     assert x.value == ureg("1m")
 
 
+def test_quantity_custom_unit_registry_context():
+
+    ureg = UnitRegistry()
+    ctx = Context()
+    ctx.add_transformation("[length]", "[time]", lambda ureg, x: x / (100 * ureg.miles) * (1.5 * ureg.hours))
+    ctx.add_transformation("[time]", "[length]", lambda ureg, x: x / (1.5 * ureg.hours) * (100 * ureg.miles))
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("hr", ureg=ureg, ureg_contexts=[ctx])]
+
+    x = TestModel(value="100mi")
+    assert x.value.m == 1.5
+    assert x.value.u == ureg.Unit("hr")
+    assert x.value == ureg("1.5hr")
+
+    x = TestModel(value="1.5hr")
+    assert x.value.m == 1.5
+    assert x.value.u == ureg.Unit("hr")
+    assert x.value == ureg("1.5hr")
+
+
 def test_quantity_custom_unit_registry_with_custom_transformations():
 
     ureg = UnitRegistry()

--- a/tests/test_quantity_restrict_dimensions.py
+++ b/tests/test_quantity_restrict_dimensions.py
@@ -1,0 +1,96 @@
+
+from __future__ import annotations
+
+import pytest
+from pint import Context, UnitRegistry
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_restrict_dimensions_length_input_string():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("[length]")]
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value="1km")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("km")
+    assert x.value == ureg("1km")
+
+    x = TestModel(value="1mm")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("mm")
+    assert x.value == ureg("1mm")
+
+
+def test_quantity_restrict_dimensions_length_input_number():
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("[length]")]
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+
+def test_quantity_restrict_dimensions_length_input_incorrect_dimension():
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("[length]")]
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1s")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1ms")
+
+
+def test_quantity_restrict_dimensions_length_input_with_custom_transformations_nonexact():
+
+    ureg = UnitRegistry()
+    ctx = Context()
+    ctx.add_transformation("[length]", "[time]", lambda ureg, x: x / (100 * ureg.miles) * (1.5 * ureg.hours))
+    ctx.add_transformation("[time]", "[length]", lambda ureg, x: x / (1.5 * ureg.hours) * (100 * ureg.miles))
+    ureg.enable_contexts(ctx)
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("[length]", exact=False, ureg=ureg)]
+
+    x = TestModel(value="100mi")
+    assert x.value.m == 100
+    assert x.value.u == ureg.Unit("mi")
+    assert x.value == ureg("100mi")
+
+    x = TestModel(value="1.5hr")
+    assert x.value.m == 1.5
+    assert x.value.u == ureg.Unit("hr")
+    assert x.value == ureg("1.5hr")
+
+
+def test_quantity_restrict_dimensions_length_input_with_custom_transformations_exact():
+
+    ureg = UnitRegistry()
+    ctx = Context()
+    ctx.add_transformation("[length]", "[time]", lambda ureg, x: x / (100 * ureg.miles) * (1.5 * ureg.hours))
+    ctx.add_transformation("[time]", "[length]", lambda ureg, x: x / (1.5 * ureg.hours) * (100 * ureg.miles))
+    ureg.enable_contexts(ctx)
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("[length]", exact=True, ureg=ureg)]
+
+    x = TestModel(value="100mi")
+    assert x.value.m == 100
+    assert x.value.u == ureg.Unit("mi")
+    assert x.value == ureg("100mi")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1.5hr")

--- a/tests/test_quantity_restrict_dimensions.py
+++ b/tests/test_quantity_restrict_dimensions.py
@@ -7,7 +7,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError
 from pydantic_pint import PydanticPintQuantity, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_restrict_dimensions_length_input_string():

--- a/tests/test_quantity_restrict_exact_units.py
+++ b/tests/test_quantity_restrict_exact_units.py
@@ -6,7 +6,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError
 from pydantic_pint import PydanticPintQuantity, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_restrict_nonstrict_nonexact_units():

--- a/tests/test_quantity_restrict_exact_units.py
+++ b/tests/test_quantity_restrict_exact_units.py
@@ -1,0 +1,93 @@
+
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_restrict_nonstrict_nonexact_units():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False, exact=False)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value="1km")
+    assert x.value.m == 1000
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1000m")
+
+
+def test_quantity_restrict_strict_nonexact_units():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=True, exact=False)]
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value="1km")
+    assert x.value.m == 1000
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1000m")
+
+
+def test_quantity_restrict_nonstrict_exact_units():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False, exact=True)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1km")
+
+
+def test_quantity_restrict_strict_exact_units():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=True, exact=True)]
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    with pytest.raises(ValidationError):
+        TestModel(value="1km")

--- a/tests/test_quantity_restrict_strict_units.py
+++ b/tests/test_quantity_restrict_strict_units.py
@@ -6,7 +6,10 @@ from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, ValidationError
 from pydantic_pint import PydanticPintQuantity, get_registry
 
-from typing_extensions import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 def test_quantity_restrict_nonstrict_units_1m():

--- a/tests/test_quantity_restrict_strict_units.py
+++ b/tests/test_quantity_restrict_strict_units.py
@@ -1,0 +1,67 @@
+
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+from typing_extensions import Annotated
+
+
+def test_quantity_restrict_nonstrict_units_1m():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=False)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+
+def test_quantity_restrict_nonstrict_units_1km():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("km", strict=False)]
+
+    x = TestModel(value=1)
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("km")
+    assert x.value == ureg("1km")
+
+
+def test_quantity_restrict_strict_units_1m():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m", strict=True)]
+
+    x = TestModel(value="1m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("m")
+    assert x.value == ureg("1m")
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)
+
+
+def test_quantity_restrict_strict_units_1km():
+
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("km", strict=True)]
+
+    x = TestModel(value="1km")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("km")
+    assert x.value == ureg("1km")
+
+    with pytest.raises(ValidationError):
+        TestModel(value=1)

--- a/tests/test_value_compare_metric_prefixes.py
+++ b/tests/test_value_compare_metric_prefixes.py
@@ -1,0 +1,147 @@
+
+from __future__ import annotations
+
+from pydantic_pint import PydanticPintValue, get_registry
+
+
+def test_value_compare_1Tm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "Tm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("Tm")
+    assert value.to("m") == ureg("1000000000000m")
+    assert value == ureg("1Tm")
+
+
+def test_value_compare_1Gm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "Gm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("Gm")
+    assert value.to("m") == ureg("1000000000m")
+    assert value == ureg("1Gm")
+
+
+def test_value_compare_1Mm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "Mm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("Mm")
+    assert value.to("m") == ureg("1000000m")
+    assert value == ureg("1Mm")
+
+
+def test_value_compare_1km():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "km")
+    assert value.m == 1
+    assert value.u == ureg.Unit("km")
+    assert value.to("m") == ureg("1000m")
+    assert value == ureg("1km")
+
+
+def test_value_compare_1hm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "hm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("hm")
+    assert value.to("m") == ureg("100m")
+    assert value == ureg("1hm")
+
+
+def test_value_compare_1dam():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "dam")
+    assert value.m == 1
+    assert value.u == ureg.Unit("dam")
+    assert value.to("m") == ureg("10m")
+    assert value == ureg("1dam")
+
+
+def test_value_compare_1m():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "m")
+    assert value.m == 1
+    assert value.u == ureg.Unit("m")
+    assert value.to("m") == ureg("1m")
+    assert value == ureg("1m")
+
+
+def test_value_compare_1dm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "dm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("dm")
+    assert value.to("m") == ureg("0.1m")
+    assert value == ureg("1dm")
+
+
+def test_value_compare_1cm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "cm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("cm")
+    assert value.to("m") == ureg("0.01m")
+    assert value == ureg("1cm")
+
+
+def test_value_compare_1mm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "mm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("mm")
+    assert value.to("m") == ureg("0.001m")
+    assert value == ureg("1mm")
+
+
+def test_value_compare_1μm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "μm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("μm")
+    assert value.to("m") == ureg("0.000001m")
+    assert value == ureg("1μm")
+
+
+def test_value_compare_1nm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "nm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("nm")
+    assert value.to("m") == ureg("0.000000001m")
+    assert value == ureg("1nm")
+
+
+def test_value_compare_1pm():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "pm")
+    assert value.m == 1
+    assert value.u == ureg.Unit("pm")
+    assert value.to("m") == ureg("0.000000000001m")
+    assert value == ureg("1pm")

--- a/tests/test_value_compare_unitless.py
+++ b/tests/test_value_compare_unitless.py
@@ -1,0 +1,26 @@
+
+from __future__ import annotations
+
+from pydantic_pint import PydanticPintValue, get_registry
+
+
+def test_value_compare_1percent():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "percent")
+    assert value.m == 1
+    assert value.u == ureg.Unit("%")
+    assert value.to("percent") == ureg("1%")
+    assert value == ureg("1%")
+
+
+def test_value_compare_1bit():
+
+    ureg = get_registry()
+
+    value = PydanticPintValue(1, "bit")
+    assert value.m == 1
+    assert value.u == ureg.Unit("bit")
+    assert value.to("percent") == ureg("100%")
+    assert value == ureg("100%")


### PR DESCRIPTION
* allow default to using `typing.Anntotated` in tests
* added unit tests for using additional annotations with `pydantic.Field` (#35)
* added unit tests for restricting the dimensions of quantity (#37)
* added unit tests for pydantic quantity validation schemas (#33)
* added unit tests for unitless quantities / values (#34)
* added unit tests for comparing pydantic pint value (#25)
* added unit tests for custom unit registry contexts (#22)
* added unit tests for custom unit registries (#21)
* added unit tests for exact mode (#23)
* added unit tests for strict mode (#20)
* added unit tests for typical usage of pydantic pint (#19)