### PR TITLE
Fixed issue where dimensions without default defined units cannot pass validation

### DIFF
--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -201,8 +201,11 @@ class PydanticPintQuantity:
         if isinstance(v, Number):
             raise ValueError(f"must specify units with dimension restriction")
         elif not self.exact and isinstance(v, Quantity):
-            if v.is_compatible_with(
-                next(iter(self.ureg._cache.dimensional_equivalents[self.dimensions]))
+            if (
+                v.check(self.dimensions) or
+                any(v.is_compatible_with(dim) for dim in
+                    self.ureg._cache.dimensional_equivalents.get(self.dimensions, [])
+                )
             ):
                 return v
             raise ValueError(f"cannot convert to dimension '{self.dimensions}'")

--- a/tests/test_quantity_restrict_dimensions.py
+++ b/tests/test_quantity_restrict_dimensions.py
@@ -112,3 +112,17 @@ def test_quantity_restrict_dimensions_length_input_with_custom_transformations_e
 
     with pytest.raises(ValidationError):
         TestModel(value="1.5hr")
+
+
+def test_quantity_restrict_dimensions_with_no_default_units_defined():
+    ureg = UnitRegistry()
+
+    class TestModel(BaseModel):
+        value: Annotated[
+            PlainQuantity, PydanticPintQuantity("[conductivity]", exact=False, ureg=ureg)
+        ]
+
+    x = TestModel(value="1 S/m")
+    assert x.value.m == 1
+    assert x.value.u == ureg.Unit("S/m")
+    assert x.value == ureg("1 S/m")


### PR DESCRIPTION
* fixed issue where dimensions without at least one default unit would fail
  
  - `v.check` will handle this
  - `v.is_compatible_with` is still required for custom unit conversions
  - also included a test case for this