### PR TITLE
Added mypy support and fixed mypy issues

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,7 +118,7 @@ If strict mode is disabled, then users may input a number (i.e. [`numbers.Number
 
 ### Value Restrictions with `pydantic.Field`
 
-The `PydanticPintValue` class is a wrapper for a `pint.Quantity` instance.
+The `pydantic_pint_value` function is a wrapper for a `pint.Quantity` instance.
 It adds methods to the `pint.Quantity` instance that allows Pydantic to interface with it.
 This in turn gives `pint.Quantity` the ability to be used within the field comparison restrictions.
 Note, the `Field` must be specified in as an annotation instead of assigned to the field.
@@ -127,11 +127,11 @@ Note, the `Field` must be specified in as an annotation instead of assigned to t
 ureg = pint.UnitRegistry()
 
 class Model(BaseModel):
-    positive:     Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(gt=PydanticPintValue(0, "m", ureg=ureg))]
-    non_negative: Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(ge=PydanticPintValue(0, "m", ureg=ureg))]
-    negative:     Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(lt=PydanticPintValue(0, "m", ureg=ureg))]
-    non_positive: Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(le=PydanticPintValue(0, "m", ureg=ureg))]
-    even:         Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(multiple_of=PydanticPintValue(2, "m", ureg=ureg))]
+    positive:     Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(gt=pydantic_pint_value(0, "m", ureg=ureg))]
+    non_negative: Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(ge=pydantic_pint_value(0, "m", ureg=ureg))]
+    negative:     Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(lt=pydantic_pint_value(0, "m", ureg=ureg))]
+    non_positive: Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(le=pydantic_pint_value(0, "m", ureg=ureg))]
+    even:         Annotated[Quantity, PydanticPintQuantity("m", ureg=ureg), Field(multiple_of=pydantic_pint_value(2, "m", ureg=ureg))]
 
 model = Model(
     positive="1m",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,11 @@ exclude_also = [
     "@(abc\\.)?abstractmethod",
 ]
 
+[tool.mypy]
+plugins = [
+    "pydantic.mypy",
+]
+
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 pythonpath = "src"

--- a/src/pydantic_pint/__init__.py
+++ b/src/pydantic_pint/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 __all__ = [
     "PydanticPintQuantity",
     "PydanticPintValue",
+    "pydantic_pint_value",
     "app_registry",
     "get_registry",
     "set_registry",
@@ -18,4 +19,4 @@ __all__ = [
 
 from .quantity import PydanticPintQuantity
 from .registry import app_registry, get_registry, set_registry
-from .value import PydanticPintValue
+from .value import PydanticPintValue, pydantic_pint_value

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -10,9 +10,14 @@ if TYPE_CHECKING:
 
 import pint
 from pint.facets.plain.quantity import PlainQuantity as Quantity
+from pint.facets.context.objects import Context
 from pydantic_core import core_schema
 
 from pydantic_pint.registry import get_registry
+
+__all__ = [
+    "PydanticPintQuantity",
+]
 
 
 class PydanticPintQuantity:
@@ -59,7 +64,7 @@ class PydanticPintQuantity:
         /,
         *,
         ureg: pint.UnitRegistry | None = None,
-        ureg_contexts: Iterable[str | pint.Context] | None = None,
+        ureg_contexts: Iterable[str | Context] | None = None,
         restriction: Literal["units", "dimensions"] | None = None,
         ser_mode: Literal["str", "dict", "number"] | None = None,
         strict: bool = True,
@@ -83,7 +88,7 @@ class PydanticPintQuantity:
 
         if self.restriction is None or self.restriction == "units":
             try:
-                _units = self.ureg(_arg).units
+                _units = self.ureg(_arg).units  # type: ignore
                 _dims = _units.dimensionality
                 self.restriction = "units"
             except AttributeError:
@@ -93,7 +98,7 @@ class PydanticPintQuantity:
         if self.restriction is None or self.restriction == "dimensions":
             try:
                 _units = None
-                _dims = self.ureg.get_dimensionality(_arg)
+                _dims = self.ureg.get_dimensionality(_arg)  # type: ignore
                 self.restriction = "dimensions"
             except ValueError:
                 if self.restriction == "dimensions":
@@ -237,7 +242,7 @@ class PydanticPintQuantity:
         Returns:
             The serialized `pint.Quantity`.
         """
-        to_json = to_json or (info and info.mode_is_json())
+        to_json = to_json or (info is not None and info.mode_is_json())
 
         if self.ser_mode == "dict":
             return {

--- a/src/pydantic_pint/registry.py
+++ b/src/pydantic_pint/registry.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-_DEFAULT_REGISTRY = pint.LazyRegistry()
+_DEFAULT_REGISTRY: pint.LazyRegistry = pint.LazyRegistry()
 
 app_registry = pint.ApplicationRegistry(_DEFAULT_REGISTRY)
 """Pydantic Pint default application registry."""

--- a/src/pydantic_pint/value.py
+++ b/src/pydantic_pint/value.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import sys
 from numbers import Number
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 import pint
 from pydantic_core import SchemaSerializer, core_schema
@@ -84,18 +90,19 @@ def pydantic_pint_value(
     return inject_pydantic_schema(inst)
 
 
-# for compatibility
-PydanticPintValue = pydantic_pint_value
-"""Proxy class for a Pint Quantity instance with pydantic serialization.
+@deprecated("use `pydantic_pint_value` instead")
+def PydanticPintValue(*args, **kwargs) -> pint.Quantity:
+    """Proxy class for a Pint Quantity instance with pydantic serialization.
 
-!!! warning
+    !!! warning
 
-    The name `PydanticPintQuantity` is deprecated. Use `pydantic_pint_value` instead.
+        The name `PydanticPintQuantity` is deprecated. Use `pydantic_pint_value` instead.
 
-Unlink `PydanticPintQuantity`, `PydanticPintValue` wraps an instance of a pint
-quantity. Methods are added to allow it to interact with pydantic, e.g. serialization.
-The class immediately resolves to a `pint.Quantity` upon construction. The primary
-use for `PydanticPintValue` is in `pydantic.Field` comparison restrictions.
+    Unlike `PydanticPintQuantity`, `PydanticPintValue` wraps an instance of a pint
+    quantity. Methods are added to allow it to interact with pydantic, e.g. serialization.
+    The class immediately resolves to a `pint.Quantity` upon construction. The primary
+    use for `PydanticPintValue` is in `pydantic.Field` comparison restrictions.
 
-See `pydantic_pint_value` for more details.
-"""
+    See `pydantic_pint_value` for more details.
+    """
+    return pydantic_pint_value(*args, **kwargs)

--- a/src/pydantic_pint/value.py
+++ b/src/pydantic_pint/value.py
@@ -9,50 +9,67 @@ from pydantic_core import SchemaSerializer, core_schema
 
 from pydantic_pint.registry import get_registry
 
+__all__ = [
+    "pydantic_pint_value",
+]
 
-class PydanticPintValue:
-    """Proxy class for a Pint Quantity instance with pydantic serialization.
 
-    Unlink `PydanticPintQuantity`, `PydanticPintValue` wraps an instance of a pint quantity.
-    Methods are added to allow it to interact with pydantic, e.g. serialization.
-    The class immediately resolves to a `pint.Quantity` upon construction.
-    The primary use for `PydanticPintValue` is in `pydantic.Field` comparison restrictions.
+def pydantic_pint_value(
+    value: Number,
+    units: str | None = None,
+    /,
+    *,
+    ureg: pint.UnitRegistry | None = None,
+) -> pint.Quantity:
+    """Construct `pint.Quantity` with an injected Pydantic schema.
+
+    A serialization schema is added to a Pint quantity to allow it to be serialized
+    by pydantic. This in-turn allows Pint values to be used in a `pydantic.Field`
+    context.
+
+    Args:
+        value (Number):
+            The magnitude of the quantity.
+        units (str | None, optional):
+            The units of the quantity.
+            Defaults to unitless quantity.
+        ureg (pint.UnitRegistry | None, optional):
+            The unit registry from which to create the quantity.
+            Defaults to `pydantic_pint.app_registry`.
+
+    Returns:
+        A `pint.Quantity` with pydantic serialization.
     """
+    ureg = ureg if ureg else get_registry()
+    inst = ureg.Quantity(value, units)
 
-    def __new__(
-        cls,
-        __value: Number,
-        __units: str | None = None,
-        /,
-        *,
-        ureg: pint.UnitRegistry | None = None,
-    ) -> pint.Quantity:
-        """Coarse value into a `pint.Quantity` based on provided unit registry.
-
-        Args:
-            __value (Number):
-                The magnitude of the quantity.
-            __units (str | None, optional):
-                The units of the quantity.
-                Defaults to unitless quantity.
-            ureg (pint.UnitRegistry | None, optional):
-                The unit registry from which to create the quantity.
-                Defaults to `pydantic_pint.app_registry`.
-
-        Returns:
-            A `pint.Quantity` with pydantic serialization.
-        """
-        ureg = ureg if ureg else get_registry()
-        inst = ureg.Quantity(__value, __units)
-
-        inst.__pydantic_serializer__ = SchemaSerializer(
-            core_schema.any_schema(
-                serialization=core_schema.plain_serializer_function_ser_schema(
-                    lambda v: str(v),
-                    info_arg=False,
-                    when_used="always",
-                )
+    schema = SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda v: str(v),
+                info_arg=False,
+                when_used="always",
             )
         )
+    )
 
-        return inst
+    setattr(inst, "__pydantic_serializer__", schema)
+
+    return inst
+
+
+# for compatibility
+PydanticPintValue = pydantic_pint_value
+"""Proxy class for a Pint Quantity instance with pydantic serialization.
+
+!!! warning
+
+    The name `PydanticPintQuantity` is deprecated. Use `pydantic_pint_value` instead.
+
+Unlink `PydanticPintQuantity`, `PydanticPintValue` wraps an instance of a pint
+quantity. Methods are added to allow it to interact with pydantic, e.g. serialization.
+The class immediately resolves to a `pint.Quantity` upon construction. The primary
+use for `PydanticPintValue` is in `pydantic.Field` comparison restrictions.
+
+See `pydantic_pint_value` for more details.
+"""

--- a/src/pydantic_pint/value.py
+++ b/src/pydantic_pint/value.py
@@ -11,7 +11,46 @@ from pydantic_pint.registry import get_registry
 
 __all__ = [
     "pydantic_pint_value",
+    "pydantic_pint_value_schema",
+    "inject_pydantic_schema",
 ]
+
+
+def pydantic_pint_value_schema() -> SchemaSerializer:
+    """The schema that can serialize a `pint.Quantity`.
+
+    Returns:
+        The serializer schema for Pydantic.
+    """
+    return SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda v: str(v),
+                info_arg=False,
+                when_used="always",
+            )
+        )
+    )
+
+
+def inject_pydantic_schema(
+    quantity: pint.Quantity,
+) -> pint.Quantity:
+    """Adds the Pydantic serializer schema to a Pint quantity.
+
+    Args:
+        quantity: The Pint quantity.
+
+    Returns:
+        The same Pint quantity with a pydantic schema.
+    """
+    setattr(
+        quantity,
+        "__pydantic_serializer__",
+        pydantic_pint_value_schema(),
+    )
+
+    return quantity
 
 
 def pydantic_pint_value(
@@ -21,7 +60,7 @@ def pydantic_pint_value(
     *,
     ureg: pint.UnitRegistry | None = None,
 ) -> pint.Quantity:
-    """Construct `pint.Quantity` with an injected Pydantic schema.
+    """Construct `pint.Quantity` with an injected Pydantic serialization schema.
 
     A serialization schema is added to a Pint quantity to allow it to be serialized
     by pydantic. This in-turn allows Pint values to be used in a `pydantic.Field`
@@ -42,20 +81,7 @@ def pydantic_pint_value(
     """
     ureg = ureg if ureg else get_registry()
     inst = ureg.Quantity(value, units)
-
-    schema = SchemaSerializer(
-        core_schema.any_schema(
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda v: str(v),
-                info_arg=False,
-                when_used="always",
-            )
-        )
-    )
-
-    setattr(inst, "__pydantic_serializer__", schema)
-
-    return inst
+    return inject_pydantic_schema(inst)
 
 
 # for compatibility

--- a/tests/test_quantity_additional_annotations.py
+++ b/tests/test_quantity_additional_annotations.py
@@ -4,7 +4,7 @@ import pytest
 from pint.facets.plain import PlainQuantity
 from pydantic import BaseModel, Field, ValidationError
 
-from pydantic_pint import PydanticPintQuantity, PydanticPintValue, get_registry
+from pydantic_pint import PydanticPintQuantity, pydantic_pint_value, get_registry
 
 try:
     from typing import Annotated
@@ -19,7 +19,7 @@ def test_quantity_additional_annotations_field_gt():
         value: Annotated[
             PlainQuantity,
             PydanticPintQuantity("m", strict=False),
-            Field(gt=PydanticPintValue(0, "m", ureg=ureg)),
+            Field(gt=pydantic_pint_value(0, "m", ureg=ureg)),
         ]
 
     # positive
@@ -56,7 +56,7 @@ def test_quantity_additional_annotations_field_ge():
         value: Annotated[
             PlainQuantity,
             PydanticPintQuantity("m", strict=False),
-            Field(ge=PydanticPintValue(0, "m", ureg=ureg)),
+            Field(ge=pydantic_pint_value(0, "m", ureg=ureg)),
         ]
 
     # positive
@@ -89,7 +89,7 @@ def test_quantity_additional_annotations_field_le():
         value: Annotated[
             PlainQuantity,
             PydanticPintQuantity("m", strict=False),
-            Field(le=PydanticPintValue(0, "m", ureg=ureg)),
+            Field(le=pydantic_pint_value(0, "m", ureg=ureg)),
         ]
 
     # positive
@@ -122,7 +122,7 @@ def test_quantity_additional_annotations_field_lt():
         value: Annotated[
             PlainQuantity,
             PydanticPintQuantity("m", strict=False),
-            Field(lt=PydanticPintValue(0, "m", ureg=ureg)),
+            Field(lt=pydantic_pint_value(0, "m", ureg=ureg)),
         ]
 
     # positive
@@ -159,7 +159,7 @@ def test_quantity_additional_annotations_field_multiple_of():
         value: Annotated[
             PlainQuantity,
             PydanticPintQuantity("m", strict=False),
-            Field(multiple_of=PydanticPintValue(2, "m", ureg=ureg)),
+            Field(multiple_of=pydantic_pint_value(2, "m", ureg=ureg)),
         ]
 
     # no units

--- a/tests/test_value_compare_metric_prefixes.py
+++ b/tests/test_value_compare_metric_prefixes.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from pydantic_pint import PydanticPintValue, get_registry
+from pydantic_pint import pydantic_pint_value, get_registry
 
 
 def test_value_compare_1Tm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "Tm")
+    value = pydantic_pint_value(1, "Tm")
     assert value.m == 1
     assert value.u == ureg.Unit("Tm")
     assert value.to("m") == ureg("1000000000000m")
@@ -16,7 +16,7 @@ def test_value_compare_1Tm():
 def test_value_compare_1Gm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "Gm")
+    value = pydantic_pint_value(1, "Gm")
     assert value.m == 1
     assert value.u == ureg.Unit("Gm")
     assert value.to("m") == ureg("1000000000m")
@@ -26,7 +26,7 @@ def test_value_compare_1Gm():
 def test_value_compare_1Mm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "Mm")
+    value = pydantic_pint_value(1, "Mm")
     assert value.m == 1
     assert value.u == ureg.Unit("Mm")
     assert value.to("m") == ureg("1000000m")
@@ -36,7 +36,7 @@ def test_value_compare_1Mm():
 def test_value_compare_1km():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "km")
+    value = pydantic_pint_value(1, "km")
     assert value.m == 1
     assert value.u == ureg.Unit("km")
     assert value.to("m") == ureg("1000m")
@@ -46,7 +46,7 @@ def test_value_compare_1km():
 def test_value_compare_1hm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "hm")
+    value = pydantic_pint_value(1, "hm")
     assert value.m == 1
     assert value.u == ureg.Unit("hm")
     assert value.to("m") == ureg("100m")
@@ -56,7 +56,7 @@ def test_value_compare_1hm():
 def test_value_compare_1dam():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "dam")
+    value = pydantic_pint_value(1, "dam")
     assert value.m == 1
     assert value.u == ureg.Unit("dam")
     assert value.to("m") == ureg("10m")
@@ -66,7 +66,7 @@ def test_value_compare_1dam():
 def test_value_compare_1m():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "m")
+    value = pydantic_pint_value(1, "m")
     assert value.m == 1
     assert value.u == ureg.Unit("m")
     assert value.to("m") == ureg("1m")
@@ -76,7 +76,7 @@ def test_value_compare_1m():
 def test_value_compare_1dm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "dm")
+    value = pydantic_pint_value(1, "dm")
     assert value.m == 1
     assert value.u == ureg.Unit("dm")
     assert value.to("m") == ureg("0.1m")
@@ -86,7 +86,7 @@ def test_value_compare_1dm():
 def test_value_compare_1cm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "cm")
+    value = pydantic_pint_value(1, "cm")
     assert value.m == 1
     assert value.u == ureg.Unit("cm")
     assert value.to("m") == ureg("0.01m")
@@ -96,7 +96,7 @@ def test_value_compare_1cm():
 def test_value_compare_1mm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "mm")
+    value = pydantic_pint_value(1, "mm")
     assert value.m == 1
     assert value.u == ureg.Unit("mm")
     assert value.to("m") == ureg("0.001m")
@@ -106,7 +106,7 @@ def test_value_compare_1mm():
 def test_value_compare_1μm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "μm")
+    value = pydantic_pint_value(1, "μm")
     assert value.m == 1
     assert value.u == ureg.Unit("μm")
     assert value.to("m") == ureg("0.000001m")
@@ -116,7 +116,7 @@ def test_value_compare_1μm():
 def test_value_compare_1nm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "nm")
+    value = pydantic_pint_value(1, "nm")
     assert value.m == 1
     assert value.u == ureg.Unit("nm")
     assert value.to("m") == ureg("0.000000001m")
@@ -126,7 +126,7 @@ def test_value_compare_1nm():
 def test_value_compare_1pm():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "pm")
+    value = pydantic_pint_value(1, "pm")
     assert value.m == 1
     assert value.u == ureg.Unit("pm")
     assert value.to("m") == ureg("0.000000000001m")

--- a/tests/test_value_compare_unitless.py
+++ b/tests/test_value_compare_unitless.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from pydantic_pint import PydanticPintValue, get_registry
+from pydantic_pint import pydantic_pint_value, get_registry
 
 
 def test_value_compare_1percent():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "percent")
+    value = pydantic_pint_value(1, "percent")
     assert value.m == 1
     assert value.u == ureg.Unit("%")
     assert value.to("percent") == ureg("1%")
@@ -16,7 +16,7 @@ def test_value_compare_1percent():
 def test_value_compare_1bit():
     ureg = get_registry()
 
-    value = PydanticPintValue(1, "bit")
+    value = pydantic_pint_value(1, "bit")
     assert value.m == 1
     assert value.u == ureg.Unit("bit")
     assert value.to("percent") == ureg("100%")


### PR DESCRIPTION
Closes #50.

To do this, it incurred a small refactor of `PydanticPintValue` as mypy errors on `__new__` not returning the same type as the class. So, I made `pydantic_pint_value` which is a functional version of the class that does the same exact thing. I also kept a deprecated function with the old name to keep backwards compatibility.

Note, this does not fix the specific issue that #50 talks about, as Pylance does not have the tooling that mypy does to enable type checking of pydantic models. Adding mypy support still does not do any introspection of `model_validator` or `field_validator` decorated functions. However, this is an issue in all pydantic models, hence the mypy plugin.

Ran mypy on all version of `python>=3.8`. Only `python==3.8` has issues due to the low version of mypy not able to assess `__init_subclass__` and the instantiation of `PlainRegistry.Quantity`. All other version pass all mypy checks.