### PR TITLE
Fixed issue where the JSON schema could not be generated for `PydanticPintQuantity`

### DIFF
--- a/changes/57.fix.md
+++ b/changes/57.fix.md
@@ -1,0 +1,2 @@
+Fixed issue that caused the serialization schema for `PydanticPintQuantity` from being created.
+This will now allow models that utilize `PydanticPintQuantity` to be used in [FastAPI](https://fastapi.tiangolo.com/) applications.

--- a/changes/61.fix.md
+++ b/changes/61.fix.md
@@ -1,0 +1,2 @@
+Fixed issues caused by `pint>=0.25.3`.
+See https://github.com/hgrecco/pint/pull/2260 for more information.

--- a/changes/62.fix.md
+++ b/changes/62.fix.md
@@ -1,0 +1,1 @@
+Included the missing serialization return schema in the Pydantic core schema for `PydanticPintQuantity`.

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -150,13 +150,19 @@ class PydanticPintQuantity:
         except KeyError as e:
             raise ValueError("no `magnitude` or `units` keys found") from e
 
+        # try converting to a number before parsing expression
+        # required for pint>=0.25.3
+        try:
+            v = float(v)
+        except (ValueError, TypeError):
+            pass
+
         try:
             if isinstance(v, str):
-                # relies on ureg to return a number if no units are present
                 # if value is a quantity, then units are present and check on the units being convertible
                 # if value is a number, then check on strict mode will happen next
                 v = self.ureg(v)
-        except pint.UndefinedUnitError as e:
+        except pint.PintError as e:
             raise ValueError(e) from e
 
         try:

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -296,7 +296,10 @@ class PydanticPintQuantity:
                         core_schema.typed_dict_schema(_from_typedict_schema),
                     ]
                 ),
-                core_schema.with_info_plain_validator_function(self.validate),
+                core_schema.with_info_before_validator_function(
+                    self.validate,
+                    core_schema.is_instance_schema(Quantity),
+                ),
             ]
         )
 
@@ -308,7 +311,10 @@ class PydanticPintQuantity:
                         core_schema.typed_dict_schema(_from_typedict_schema),
                     ]
                 ),
-                core_schema.no_info_plain_validator_function(self.validate),
+                core_schema.with_info_before_validator_function(
+                    self.validate,
+                    core_schema.any_schema(),
+                ),
             ]
         )
 

--- a/src/pydantic_pint/quantity.py
+++ b/src/pydantic_pint/quantity.py
@@ -227,7 +227,7 @@ class PydanticPintQuantity:
         info: core_schema.SerializationInfo | None = None,
         *,
         to_json: bool = False,
-    ) -> dict | str | Quantity:
+    ) -> dict | str | Number | Quantity:
         """Serialize `PydanticPintQuantity`.
 
         Args:
@@ -318,9 +318,24 @@ class PydanticPintQuantity:
             ]
         )
 
+        if self.ser_mode == "dict":
+            _ser_return_schema = core_schema.typed_dict_schema(
+                {
+                    "magnitude": core_schema.typed_dict_field(core_schema.float_schema()),
+                    "units": core_schema.typed_dict_field(core_schema.str_schema()),
+                }
+            )
+        elif self.ser_mode == "number":
+            _ser_return_schema = core_schema.float_schema()
+        else:
+            # self.ser_mode == "str"
+            # serialization defaults to `str` in JSON serialization mode
+            _ser_return_schema = core_schema.str_schema()
+
         serialize_schema = core_schema.plain_serializer_function_ser_schema(
             self.serialize,
             info_arg=True,
+            return_schema=_ser_return_schema,
         )
 
         return core_schema.json_or_python_schema(

--- a/tests/test_quantity_restrict_dimensions.py
+++ b/tests/test_quantity_restrict_dimensions.py
@@ -117,6 +117,12 @@ def test_quantity_restrict_dimensions_length_input_with_custom_transformations_e
 def test_quantity_restrict_dimensions_with_no_default_units_defined():
     ureg = UnitRegistry()
 
+    # only run this test if conductivity is an acceptable dimension
+    try:
+        ureg.get_dimensionality("[conductivity]")
+    except (ValueError, KeyError):
+        return
+
     class TestModel(BaseModel):
         value: Annotated[
             PlainQuantity, PydanticPintQuantity("[conductivity]", exact=False, ureg=ureg)

--- a/tests/test_quantity_schema_generation.py
+++ b/tests/test_quantity_schema_generation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError
+from pydantic.json_schema import JsonSchemaValue
+
+from pydantic_pint import PydanticPintQuantity, get_registry
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+
+def test_quantity_schema_generation_validation():
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    schema = TestModel.model_json_schema(mode="validation")
+    assert isinstance(schema, dict)
+
+def test_quantity_schema_generation_serialization():
+
+    class TestModel(BaseModel):
+        value: Annotated[PlainQuantity, PydanticPintQuantity("m")]
+
+    schema = TestModel.model_json_schema(mode="serialization")
+    assert isinstance(schema, dict)

--- a/tests/test_value_schema_generation.py
+++ b/tests/test_value_schema_generation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ValidationError, Field
+
+from pydantic_pint import PydanticPintQuantity, pydantic_pint_value, get_registry
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+
+def test_quantity_schema_generation_validation():
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[
+            PlainQuantity,
+            PydanticPintQuantity("m", strict=False),
+            Field(gt=pydantic_pint_value(0, "m", ureg=ureg)),
+        ]
+
+    schema = TestModel.model_json_schema(mode="validation")
+    assert isinstance(schema, dict)
+
+def test_quantity_schema_generation_serialization():
+    ureg = get_registry()
+
+    class TestModel(BaseModel):
+        value: Annotated[
+            PlainQuantity,
+            PydanticPintQuantity("m", strict=False),
+            Field(gt=pydantic_pint_value(0, "m", ureg=ureg)),
+        ]
+
+    schema = TestModel.model_json_schema(mode="serialization")
+    assert isinstance(schema, dict)


### PR DESCRIPTION
Closes #57.
Closes #61.
Closes #62.

The issue is related to `core_schema.no_info_plain_validation_schema` that is used on validation. Everything worked originally for validation but not serialization.

The change was to the schema to be `core_schema.no_info_before_validation_schema`. This schema is supported by the `pydantic.json_schema.GenerateJsonSchema` generator.

The inner schema is to check the output of the validation function. Unfortunately, the `core_schema.isinstance_schema` is not supported. The best that can be done is using a `core_schema.any_schema` to match any type. The validation function will always return an instance `pint.Quantity` (this may need be an issue when using different types of `Quantity` types, e.g. `NumpyQuantity`).

Tests have been included to ensure the schema can always be generated for JSON (e.g. from calling `BaseModel.model_json_schema`).
